### PR TITLE
chore: Add Stylelint rule

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,5 +5,8 @@
       "files": ["**/*.tsx"],
       "customSyntax": "@stylelint/postcss-css-in-js"
     }
-  ]
+  ],
+  "rules": {
+    "function-no-unknown": [true, { "ignoreFunctions": ["/\\${/"] }]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
+    "test:ci": "react-scripts test --watchAll=false",
     "format": "prettier --check ./src",
     "format:fix": "prettier --write ./src",
     "lint": "eslint ./src",


### PR DESCRIPTION
I added `Stylelint` rule to fix the `function-no-unknown` error

```bash
✖  Unexpected unknown function "${"         function-no-unknown    
```