### PR TITLE
style: Turn off react/react-in-jsx-scope eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -119,5 +119,6 @@ module.exports = {
         },
       },
     ],
+    'react/react-in-jsx-scope': 'off',
   },
 }


### PR DESCRIPTION
The `import React from 'react'` is not needed from `React 17`.

- Document: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

So, I turn off the ESLint rule and remove the codes.