### PR TITLE
chore: Activate no-unused-vars rule of ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,7 +62,7 @@ module.exports = {
     '@typescript-eslint/no-unnecessary-type-arguments': 'error',
     'no-unused-expressions': 'off',
     '@typescript-eslint/no-unused-expressions': 'error',
-    '@typescript-eslint/no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': 'error',
     '@typescript-eslint/no-use-before-define': [
       'error',
       {

--- a/src/components/SampleButton/index.tsx
+++ b/src/components/SampleButton/index.tsx
@@ -3,10 +3,9 @@ import { Button } from '@mui/material'
 import type { ButtonProps } from '@mui/material'
 
 const StyledButton = styled(
-  ({
-    backgroundColor,
-    ...props
-  }: Pick<Props, 'backgroundColor'> & ButtonProps) => <Button {...props} />,
+  (props: Pick<Props, 'backgroundColor'> & ButtonProps) => (
+    <Button {...props} />
+  ),
 )`
   ${(props) =>
     props.backgroundColor != null


### PR DESCRIPTION
I activated the `no-unused-vars` rule of `ESLint` and fixed the error.