### PR TITLE
refactor: Use MUI styled instead of Emtion styled

### DIFF
--- a/src/components/SampleButton/index.tsx
+++ b/src/components/SampleButton/index.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import { Button } from '@mui/material'
 import type { ButtonProps } from '@mui/material'
+import { styled } from '@mui/system'
 
 const StyledButton = styled(
   (props: Pick<Props, 'backgroundColor'> & ButtonProps) => (

--- a/src/components/organisms/BlogItem/index.tsx
+++ b/src/components/organisms/BlogItem/index.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import { Grid, Typography } from '@mui/material'
+import { styled } from '@mui/system'
 
 const Container = styled(Grid)`
   background-color: #fff;


### PR DESCRIPTION
I decided to use the `styled` function of `MUI` instead of the `styled` of `Emotion`.

- Document: https://mui.com/system/styled/