### PR TITLE
fix: Fix React does not recognize the XXX prop on a DOM element wanring

### DIFF
--- a/src/components/SampleButton/index.tsx
+++ b/src/components/SampleButton/index.tsx
@@ -2,11 +2,9 @@ import { Button } from '@mui/material'
 import type { ButtonProps } from '@mui/material'
 import { styled } from '@mui/system'
 
-const StyledButton = styled(
-  (props: Pick<Props, 'backgroundColor'> & ButtonProps) => (
-    <Button {...props} />
-  ),
-)`
+const StyledButton = styled(Button, {
+  shouldForwardProp: (propName) => propName !== 'backgroundColor',
+})<Pick<Props, 'backgroundColor'> & ButtonProps>`
   ${(props) =>
     props.backgroundColor != null
       ? `background-color: ${props.backgroundColor};`


### PR DESCRIPTION
I got a warning message like the following.

> Warning: React does not recognize the `backgroundColor` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `backgroundcolor` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

And, I fixed it with `shouldForwardProp`.

- Document: https://emotion.sh/docs/styled#customizing-prop-forwarding