### PR TITLE
feat: Add <ErrorMessage /> atom component

### DIFF
--- a/src/components/atoms/ErrorMessage/__snapshots__/index.test.tsx.snap
+++ b/src/components/atoms/ErrorMessage/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ErrorMessage /> Rendered well 1`] = `
+<div>
+  <button>
+    Show
+  </button>
+</div>
+`;

--- a/src/components/atoms/ErrorMessage/index.stories.tsx
+++ b/src/components/atoms/ErrorMessage/index.stories.tsx
@@ -1,0 +1,35 @@
+import type { ComponentStory, ComponentMeta } from '@storybook/react'
+import { errorMessageState } from 'data/ErrorMessage'
+import { RecoilRoot, useSetRecoilState } from 'recoil'
+
+import { ErrorMessage } from '.'
+
+export default {
+  title: 'Atoms/ErrorMessage',
+  component: ErrorMessage,
+} as ComponentMeta<typeof ErrorMessage>
+
+interface TestComponentProps {
+  readonly errorMessage: string
+}
+const TestComponent = ({ errorMessage }: TestComponentProps) => {
+  const setErrorMessage = useSetRecoilState(errorMessageState)
+
+  return (
+    <>
+      <ErrorMessage />
+      <button onClick={() => setErrorMessage(errorMessage)}>Show</button>
+    </>
+  )
+}
+
+const Template: ComponentStory<typeof TestComponent> = (args) => (
+  <RecoilRoot>
+    <TestComponent {...args} />
+  </RecoilRoot>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  errorMessage: 'This is a sample error message',
+}

--- a/src/components/atoms/ErrorMessage/index.test.tsx
+++ b/src/components/atoms/ErrorMessage/index.test.tsx
@@ -1,0 +1,79 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { errorMessageState } from 'data/ErrorMessage'
+import { RecoilRoot, useSetRecoilState } from 'recoil'
+import { mockSnackbar } from 'utils/test'
+
+import { ErrorMessage } from '.'
+
+jest.useFakeTimers()
+
+describe('<ErrorMessage />', () => {
+  it('Rendered well', async () => {
+    const TestComponent = () => {
+      const setErrorMessage = useSetRecoilState(errorMessageState)
+
+      return (
+        <>
+          <ErrorMessage />
+          <button
+            onClick={() => setErrorMessage('This is a test error message')}
+          >
+            Show
+          </button>
+        </>
+      )
+    }
+
+    const { container } = render(
+      <RecoilRoot>
+        <TestComponent />
+      </RecoilRoot>,
+    )
+
+    let snackbar = mockSnackbar.mock.calls[0][0]
+    expect(snackbar.open).toBe(false)
+    expect(snackbar.autoHideDuration).toBe(3000)
+    expect(snackbar.onClose.name).toBe('handleClose')
+    expect(snackbar.anchorOrigin).toEqual({
+      vertical: 'bottom',
+      horizontal: 'center',
+    })
+
+    let alert = snackbar.children
+    expect(alert.type.render.name).toBe('Alert')
+    expect(alert.props.onClose.name).toBe('handleClose')
+    expect(alert.props.severity).toBe('error')
+    expect(alert.props.sx).toEqual({ width: '100%' })
+    expect(alert.props.children).toBe(undefined)
+
+    mockSnackbar.mockClear()
+    fireEvent.click(screen.getByText('Show'))
+
+    snackbar = mockSnackbar.mock.calls[1][0]
+    expect(snackbar.open).toBe(true)
+    alert = snackbar.children
+    expect(alert.props.children).toBe('This is a test error message')
+
+    mockSnackbar.mockClear()
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    snackbar = mockSnackbar.mock.calls[0][0]
+    expect(snackbar.open).toBe(false)
+    alert = snackbar.children
+    expect(alert.props.children).toBe('This is a test error message')
+
+    mockSnackbar.mockClear()
+    act(() => {
+      jest.runOnlyPendingTimers()
+    })
+
+    snackbar = mockSnackbar.mock.calls[0][0]
+    expect(snackbar.open).toBe(false)
+    alert = snackbar.children
+    expect(alert.props.children).toBe(undefined)
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/src/components/atoms/ErrorMessage/index.tsx
+++ b/src/components/atoms/ErrorMessage/index.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+
+import { Alert, Snackbar } from '@mui/material'
+import { errorMessageState } from 'data/ErrorMessage'
+import { useRecoilState } from 'recoil'
+
+export const ErrorMessage = () => {
+  const [open, setOpen] = useState(false)
+  const [errorMessage, setErrorMessage] = useRecoilState(errorMessageState)
+
+  const handleClose = () => {
+    setOpen(false)
+    setTimeout(() => setErrorMessage(undefined), 100)
+  }
+
+  useEffect(() => {
+    if (errorMessage !== undefined && errorMessage !== '') {
+      setOpen(true)
+    }
+  }, [errorMessage])
+
+  return (
+    <Snackbar
+      open={open}
+      autoHideDuration={3000}
+      onClose={handleClose}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+    >
+      <Alert onClose={handleClose} severity="error" sx={{ width: '100%' }}>
+        {errorMessage}
+      </Alert>
+    </Snackbar>
+  )
+}

--- a/src/data/ErrorMessage/index.test.ts
+++ b/src/data/ErrorMessage/index.test.ts
@@ -1,0 +1,26 @@
+import { snapshot_UNSTABLE } from 'recoil'
+
+import { errorMessageState } from './index'
+
+describe('[Data] admin info', () => {
+  test('set errorMessageState', () => {
+    const initialSnapshot = snapshot_UNSTABLE()
+    expect(initialSnapshot.getLoadable(errorMessageState).valueOrThrow()).toBe(
+      undefined,
+    )
+
+    let testSnapshot = snapshot_UNSTABLE(({ set }) =>
+      set(errorMessageState, 'This is an error message'),
+    )
+    expect(testSnapshot.getLoadable(errorMessageState).valueOrThrow()).toBe(
+      'This is an error message',
+    )
+
+    testSnapshot = snapshot_UNSTABLE(({ set }) =>
+      set(errorMessageState, undefined),
+    )
+    expect(testSnapshot.getLoadable(errorMessageState).valueOrThrow()).toBe(
+      undefined,
+    )
+  })
+})

--- a/src/data/ErrorMessage/index.ts
+++ b/src/data/ErrorMessage/index.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil'
+
+export const errorMessageState = atom<string | undefined>({
+  key: 'ERROR_MESSAGE_STATE',
+  default: undefined,
+})

--- a/src/utils/test/mocks/mui.tsx
+++ b/src/utils/test/mocks/mui.tsx
@@ -2,6 +2,7 @@ const mockAppBar = jest.fn()
 const mockToolbar = jest.fn()
 const mockTypography = jest.fn()
 const mockGrid = jest.fn()
+const mockSnackbar = jest.fn()
 
 jest.mock('@mui/material', () => {
   const {
@@ -9,6 +10,7 @@ jest.mock('@mui/material', () => {
     Toolbar: MUIToolbar,
     Typography: MUITypography,
     Grid: MUIGrid,
+    Snackbar: MUISnackbar,
     ...rest
   } = jest.requireActual('@mui/material')
 
@@ -32,13 +34,19 @@ jest.mock('@mui/material', () => {
     return <MUIGrid {...props} />
   }
 
+  const Snackbar = (props: typeof MUISnackbar) => {
+    mockSnackbar(props)
+    return <MUISnackbar {...props} />
+  }
+
   return {
     AppBar,
     Toolbar,
     Typography,
     Grid,
+    Snackbar,
     ...rest,
   }
 })
 
-export { mockAppBar, mockToolbar, mockTypography, mockGrid }
+export { mockAppBar, mockToolbar, mockTypography, mockGrid, mockSnackbar }


### PR DESCRIPTION
I add the `<ErrorMessage />` atom component.

| Normal | Error |
| -- | -- |
| ![Screenshot 2022-10-30 at 22 04 50](https://user-images.githubusercontent.com/42969906/198880026-e0790f9c-7571-4084-b15f-8a3c61ecd718.jpg) | ![Screenshot 2022-10-30 at 22 04 52](https://user-images.githubusercontent.com/42969906/198880041-34fe1f40-36cd-49f0-8b1f-504e21f73cbf.jpg) |
