### PR TITLE
fix: Fix wrong return type of post detail API

### DIFF
--- a/src/api/posts/index.test.tsx
+++ b/src/api/posts/index.test.tsx
@@ -71,7 +71,7 @@ describe('[API] useGetPost', () => {
     )
     let result:
       | {
-          current: UseQueryResult<ReadonlyArray<Post>>
+          current: UseQueryResult<Post>
         }
       | undefined
 
@@ -95,7 +95,7 @@ describe('[API] useGetPost', () => {
     )
     let result:
       | {
-          current: UseQueryResult<ReadonlyArray<Post>>
+          current: UseQueryResult<Post>
         }
       | undefined
 

--- a/src/api/posts/index.ts
+++ b/src/api/posts/index.ts
@@ -19,7 +19,7 @@ export const useGetPosts = () => {
 interface GetPostParams {
   readonly id: number
 }
-const getPost = async ({ id }: GetPostParams): Promise<ReadonlyArray<Post>> => {
+const getPost = async ({ id }: GetPostParams): Promise<Post> => {
   const response = await axios.get(`${POSTS_URL}/${id}`)
 
   return response.data


### PR DESCRIPTION
There is a copy-paste miss.

I fix the wrong return type of the post detail API.