### PR TITLE
feat: Add enable option to getting post detail API

### DIFF
--- a/src/api/posts/index.test.tsx
+++ b/src/api/posts/index.test.tsx
@@ -111,4 +111,23 @@ describe('[API] useGetPost', () => {
 
     expect((result?.current.error as AxiosError).response?.status).toBe(400)
   })
+
+  it('idle', async () => {
+    const wrapper = ({ children }: { children: JSX.Element }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    let result:
+      | {
+          current: UseQueryResult<Post>
+        }
+      | undefined
+
+    await act(async () => {
+      result = renderHook(() => useGetPost({ id: null }), {
+        wrapper,
+      }).result
+    })
+
+    expect(result?.current.fetchStatus).toBe('idle')
+  })
 })

--- a/src/api/posts/index.ts
+++ b/src/api/posts/index.ts
@@ -17,7 +17,7 @@ export const useGetPosts = () => {
 }
 
 interface GetPostParams {
-  readonly id: number
+  readonly id: number | null
 }
 const getPost = async ({ id }: GetPostParams): Promise<Post> => {
   const response = await axios.get(`${POSTS_URL}/${id}`)
@@ -28,5 +28,6 @@ const getPost = async ({ id }: GetPostParams): Promise<Post> => {
 export const useGetPost = ({ id }: GetPostParams) => {
   return useQuery(['GetPost', id], async () => getPost({ id }), {
     refetchOnWindowFocus: false,
+    enabled: id != null,
   })
 }


### PR DESCRIPTION
I add the `enable` option to the getting post detail API.