### PR TITLE
refactor: Use Router instead of unstable_HistoryRouter for test

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react'
 import mockPostData from 'api/posts/mockData/post.json'
 import mockPostsData from 'api/posts/mockData/posts.json'
 import { createMemoryHistory } from 'history'
-import { unstable_HistoryRouter as HistoryRouter } from 'react-router-dom'
+import { Router } from 'react-router-dom'
 import {
   mockBlogListPage,
   mockHeader,
@@ -22,9 +22,9 @@ describe('<App />', () => {
     const history = createMemoryHistory({ initialEntries: ['/'] })
 
     render(
-      <HistoryRouter history={history}>
+      <Router location={history.location} navigator={history}>
         <App />
-      </HistoryRouter>,
+      </Router>,
     )
 
     expect(mockPageContainer.mock.calls.length).toBe(1)
@@ -38,9 +38,9 @@ describe('<App />', () => {
     const history = createMemoryHistory({ initialEntries: ['/posts/1'] })
 
     render(
-      <HistoryRouter history={history}>
+      <Router location={history.location} navigator={history}>
         <App />
-      </HistoryRouter>,
+      </Router>,
     )
 
     expect(mockPageContainer.mock.calls.length).toBe(1)

--- a/src/components/atoms/FloatingActionLink/index.test.tsx
+++ b/src/components/atoms/FloatingActionLink/index.test.tsx
@@ -1,10 +1,7 @@
 import AddIcon from '@mui/icons-material/Add'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
-import {
-  BrowserRouter,
-  unstable_HistoryRouter as HistoryRouter,
-} from 'react-router-dom'
+import { BrowserRouter, Router } from 'react-router-dom'
 import { mockLink } from 'utils/test'
 
 import { FloatingActionLink } from '.'
@@ -72,9 +69,9 @@ describe('<FloatingActionLink />', () => {
     history.push = mockPush
 
     render(
-      <HistoryRouter history={history}>
+      <Router location={history.location} navigator={history}>
         <FloatingActionLink link="/posts/add">Add</FloatingActionLink>,
-      </HistoryRouter>,
+      </Router>,
     )
 
     fireEvent.click(screen.getByText('Add'))

--- a/src/components/atoms/Link/index.test.tsx
+++ b/src/components/atoms/Link/index.test.tsx
@@ -1,9 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
-import {
-  BrowserRouter,
-  unstable_HistoryRouter as HistoryRouter,
-} from 'react-router-dom'
+import { BrowserRouter, Router } from 'react-router-dom'
 
 import { Link } from '.'
 
@@ -30,9 +27,9 @@ describe('<Link />', () => {
     history.push = mockPush
 
     render(
-      <HistoryRouter history={history}>
+      <Router location={history.location} navigator={history}>
         <Link to="/posts/1">test link</Link>
-      </HistoryRouter>,
+      </Router>,
     )
 
     fireEvent.click(screen.getByText('test link'))

--- a/src/components/organisms/BlogItem/index.test.tsx
+++ b/src/components/organisms/BlogItem/index.test.tsx
@@ -1,9 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
-import {
-  BrowserRouter,
-  unstable_HistoryRouter as HistoryRouter,
-} from 'react-router-dom'
+import { BrowserRouter, Router } from 'react-router-dom'
 import { mockGrid } from 'utils/test'
 
 import { BlogItem } from '.'
@@ -45,13 +42,13 @@ describe('<BlogItem />', () => {
     history.push = mockPush
 
     render(
-      <HistoryRouter history={history}>
+      <Router location={history.location} navigator={history}>
         <BlogItem
           id={2}
           title="This is the blog title."
           body="This is the blog contents."
         />
-      </HistoryRouter>,
+      </Router>,
     )
 
     fireEvent.click(screen.getByText('This is the blog title.'))

--- a/src/components/organisms/Header/index.test.tsx
+++ b/src/components/organisms/Header/index.test.tsx
@@ -1,9 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
-import {
-  BrowserRouter,
-  unstable_HistoryRouter as HistoryRouter,
-} from 'react-router-dom'
+import { BrowserRouter, Router } from 'react-router-dom'
 import { mockAppBar } from 'utils/test'
 
 import { Header } from '.'
@@ -48,9 +45,9 @@ describe('<Header />', () => {
     history.push = mockPush
 
     render(
-      <HistoryRouter history={history}>
+      <Router location={history.location} navigator={history}>
         <Header />
-      </HistoryRouter>,
+      </Router>,
     )
 
     fireEvent.click(screen.getByText('Blog App'))

--- a/src/components/pages/PostDetailPage/index.test.tsx
+++ b/src/components/pages/PostDetailPage/index.test.tsx
@@ -1,11 +1,7 @@
 import { render } from '@testing-library/react'
 import mockPostData from 'api/posts/mockData/post.json'
 import { createMemoryHistory } from 'history'
-import {
-  Routes,
-  Route,
-  unstable_HistoryRouter as HistoryRouter,
-} from 'react-router-dom'
+import { Routes, Route, Router } from 'react-router-dom'
 import type { Post } from 'types'
 import { mockBlogDetail } from 'utils/test'
 
@@ -27,11 +23,11 @@ describe('<PostDetailPage />', () => {
     mockResponse = { data: mockPostData }
 
     const { container } = render(
-      <HistoryRouter history={history}>
+      <Router location={history.location} navigator={history}>
         <Routes>
           <Route path="/posts/:id" element={<PostDetailPage />} />
         </Routes>
-      </HistoryRouter>,
+      </Router>,
     )
 
     expect(mockBlogDetail.mock.calls.length).toBe(1)
@@ -44,11 +40,11 @@ describe('<PostDetailPage />', () => {
     mockResponse = { data: undefined }
 
     const { container } = render(
-      <HistoryRouter history={history}>
+      <Router location={history.location} navigator={history}>
         <Routes>
           <Route path="/posts/:id" element={<PostDetailPage />} />
         </Routes>
-      </HistoryRouter>,
+      </Router>,
     )
 
     expect(mockBlogDetail.mock.calls.length).toBe(1)
@@ -62,11 +58,11 @@ describe('<PostDetailPage />', () => {
     history = createMemoryHistory({ initialEntries: ['/posts/aaa'] })
 
     render(
-      <HistoryRouter history={history}>
+      <Router location={history.location} navigator={history}>
         <Routes>
           <Route path="/posts/:id" element={<PostDetailPage />} />
         </Routes>
-      </HistoryRouter>,
+      </Router>,
     )
 
     expect(mockBlogDetail.mock.calls.length).toBe(1)

--- a/src/components/templates/BlogDetail/index.test.tsx
+++ b/src/components/templates/BlogDetail/index.test.tsx
@@ -1,9 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { createMemoryHistory } from 'history'
-import {
-  BrowserRouter,
-  unstable_HistoryRouter as HistoryRouter,
-} from 'react-router-dom'
+import { BrowserRouter, Router } from 'react-router-dom'
 import { mockToolbar, mockGrid } from 'utils/test'
 
 import { BlogDetail } from '.'
@@ -100,7 +97,7 @@ describe('<BlogDetail />', () => {
     history.push = mockPush
 
     render(
-      <HistoryRouter history={history}>
+      <Router location={history.location} navigator={history}>
         <BlogDetail
           post={{
             userId: 1,
@@ -110,7 +107,7 @@ describe('<BlogDetail />', () => {
           }}
         />
         ,
-      </HistoryRouter>,
+      </Router>,
     )
 
     fireEvent.click(screen.getByText('Posts'))


### PR DESCRIPTION
I use `Router` instead of `unstable_HistoryRouter` for the test.